### PR TITLE
Link to Usenet messages via their Message-ID

### DIFF
--- a/site/docs/ref/history.md
+++ b/site/docs/ref/history.md
@@ -110,7 +110,7 @@ created the Module List,
 which was a manually edited text file containing an index
 of all known Perl 5 modules.
 I don't have a copy of the first-ever list,
-but [revision 2.2](https://groups.google.com/forum/#!searchin/comp.lang.perl/"The$20Perl$205$20Module$20List"/comp.lang.perl/3tyvjwLfNDA/21Fd-EDvXOsJ) was posted 7th March 1995.
+but [revision 2.2](http://groups.google.com/groups?selm=perl-faq/module-list-1-794455075%40ig.co.uk) was posted 7th March 1995.
 For a long time this was the place to look,
 to find out what modules were available for Perl 5.
 
@@ -155,7 +155,7 @@ proposing a directory structure, and that he was going to get on with it.
 > *For me this is a key moment.
 > It needed someone to say "right, I'm gonna do it"*
 >
-> ["Nothing gets done without someone doing it"](https://groups.google.com/forum/#!searchin/comp.lang.perl/larry$20wall$20nothing$20gets$20done/comp.lang.perl/rSvC42jEiWs/RX5yrkKy_TIJ) &mdash; Larry Wall 1994-11-08 (ie not in response to this).
+> ["Nothing gets done without someone doing it"](http://groups.google.com/groups?selm=1994Nov8.014614.13584%40netlabs.com) &mdash; Larry Wall 1994-11-08 (ie not in response to this).
 
 JARED followed up on the 20th with some proposed principles
 (easy to maintain, easy to submit, things should have an abstract,
@@ -275,7 +275,7 @@ Oct 16th: ANDK "I'm tempted to call franz the PAUSE, the Perl Authors Upload SEr
 
 ## The CPAN years
 
-Oct 26th: JHI announced CPAN to c.l.p.a https://groups.google.com/forum/#!topic/comp.lang.perl.announce/1qlLHdviZlY
+Oct 26th: [JHI announced CPAN to c.l.p.a](http://groups.google.com/groups?selm=46o5va$33f%40maureen.teleport.com)
 
 May 1996: Gisle Aas ([GAAS](https://metacpan.org/author/GAAS))
 released the first version of libwww-perl-5 (aka LWP).


### PR DESCRIPTION
That way the links will hopefully remain resolvable across future Usenet archives to come (even after Google has totally destroyed the usefulness of theirs).